### PR TITLE
chore: removing node7 job from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 unit_tests:
-  steps: &ref_0
+  steps: &unit_tests
     - checkout
     - run:
         name: Install modules and dependencies.
@@ -76,17 +76,17 @@ jobs:
     docker:
       - image: 'node:6'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   node8:
     docker:
       - image: 'node:8'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   node9:
     docker:
       - image: 'node:9'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   lint:
     docker:
       - image: 'node:8'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
----
-# "Include" for unit tests definition.
-unit_tests: &unit_tests
-  steps:
+unit_tests:
+  steps: &ref_0
     - checkout
     - run:
         name: Install modules and dependencies.
@@ -16,8 +14,7 @@ unit_tests: &unit_tests
         name: Submit coverage data to codecov.
         command: node_modules/.bin/codecov
         when: always
-
-version: 2.0
+version: 2
 workflows:
   version: 2
   tests:
@@ -27,10 +24,6 @@ workflows:
             tags:
               only: /.*/
       - node6:
-          filters:
-            tags:
-              only: /.*/
-      - node7:
           filters:
             tags:
               only: /.*/
@@ -46,13 +39,11 @@ workflows:
           requires:
             - node4
             - node6
-            - node7
             - node8
             - node9
           filters:
             tags:
               only: /.*/
-
       - publish_npm:
           requires:
             - lint
@@ -60,12 +51,11 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[\d.]+$/
-
+              only: '/^v[\d.]+$/'
 jobs:
   node4:
     docker:
-      - image: node:4
+      - image: 'node:4'
         user: node
     steps:
       - checkout
@@ -84,28 +74,22 @@ jobs:
           when: always
   node6:
     docker:
-      - image: node:6
+      - image: 'node:6'
         user: node
-    <<: *unit_tests
-  node7:
-    docker:
-      - image: node:7
-        user: node
-    <<: *unit_tests
+    steps: *ref_0
   node8:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
-    <<: *unit_tests
+    steps: *ref_0
   node9:
     docker:
-      - image: node:9
+      - image: 'node:9'
         user: node
-    <<: *unit_tests
-
+    steps: *ref_0
   lint:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -122,19 +106,18 @@ jobs:
           command: npm run lint
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
-
   publish_npm:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
       - run:
           name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
       - run:
           name: Install modules and dependencies.
           command: npm install
       - run:
-         name: Publish the module to npm.
-         command: npm publish --access=public
+          name: Publish the module to npm.
+          command: npm publish --access=public


### PR DESCRIPTION
We don't need to test on Node 7 anymore. Note: no action is required for this PR for now.