### PR TITLE
fix(test): bracket bug

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -108,7 +108,10 @@ describe('google-proto-files', function() {
   });
   it('should export iam', function() {
     assert(googleProtoFiles.iam);
-    assert.strictEqual(googleProtoFiles.iam.v1, resolve('iam/v1/iam_policy.proto'));
+    assert.strictEqual(
+      googleProtoFiles.iam.v1,
+      resolve('iam/v1/iam_policy.proto')
+    );
   });
   it('should export iam admin', function() {
     assert(googleProtoFiles.iam.admin);
@@ -149,7 +152,10 @@ describe('google-proto-files', function() {
   });
   it('should export pubsub', function() {
     assert(googleProtoFiles.pubsub);
-    assert.strictEqual(googleProtoFiles.pubsub.v1, resolve('pubsub/v1/pubsub.proto'));
+    assert.strictEqual(
+      googleProtoFiles.pubsub.v1,
+      resolve('pubsub/v1/pubsub.proto')
+    );
     assert.strictEqual(
       googleProtoFiles.pubsub.v1beta2,
       resolve('pubsub/v1beta2/pubsub.proto')

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -43,7 +43,7 @@ describe('loadSync', function() {
   it('should not be able to load test file using protobufjs directly', function() {
     var root = protobuf.loadSync(TEST_FILE);
     // Common proto that should not have been loaded.
-    assert.strictEqual(root.lookup('google.api.Http'), undefined);
+    assert.strictEqual(root.lookup('google.api.Http'), null);
   });
 
   it('should load a test file that relies on common protos', function() {

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -43,7 +43,7 @@ describe('loadSync', function() {
   it('should not be able to load test file using protobufjs directly', function() {
     var root = protobuf.loadSync(TEST_FILE);
     // Common proto that should not have been loaded.
-    assert.strictEqual(root.lookup('google.api.Http', undefined));
+    assert.strictEqual(root.lookup('google.api.Http'), undefined);
   });
 
   it('should load a test file that relies on common protos', function() {

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -43,7 +43,7 @@ describe('loadSync', function() {
   it('should not be able to load test file using protobufjs directly', function() {
     var root = protobuf.loadSync(TEST_FILE);
     // Common proto that should not have been loaded.
-    assert.strictEqual(root.lookup('google.api.Http', null));
+    assert.strictEqual(root.lookup('google.api.Http', undefined));
   });
 
   it('should load a test file that relies on common protos', function() {


### PR DESCRIPTION
bracketing bug:
`assert.strictEqual(root.lookup('google.api.Http', null))`

This will fix #64 