### PR TITLE
feat: include google/protobuf/compiler

### DIFF
--- a/tools/prepublish.ts
+++ b/tools/prepublish.ts
@@ -57,7 +57,6 @@ async function main() {
       return (
         file.parent.indexOf('protobuf-master') === 0 &&
         file.parent.indexOf('protobuf-master/src/') === 0 &&
-        file.parent.indexOf('/compiler') === -1 &&
         file.parent.indexOf('/internal') === -1 &&
         file.filename.indexOf('unittest') === -1 &&
         file.filename.indexOf('test') === -1


### PR DESCRIPTION
Long story short:

- gax uses this package offline to get the proto files from it;
- TypeScript micro-generator wants to take proto files from gax instead of having its own copy
- TypeScript micro-generator needs to have `google/protobuf/compiler`

So here we go!

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
