### PR TITLE
fix: TypeScript error in got package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",
     "@types/mocha": "^7.0.0",
+    "@types/node": "^14.0.20",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^9.0.0",
     "c8": "^7.0.0",


### PR DESCRIPTION
Fixes broken TypeScript compilation:

```
> google-proto-files@2.1.1 compile /Users/fenster/nodejs-packages/nodejs-proto-files
> tsc -p .

node_modules/got/dist/source/core/index.d.ts:299:5 - error TS2416: Property '_write' in type 'Request' is not assignable to the same property in base type 'Duplex'.
  Type '(chunk: any, encoding: "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | undefined, callback: (error?: ErrnoException | null | undefined) => void) => void' is not assignable to type '(chunk: any, encoding: string, callback: (error?: Error | null | undefined) => void) => void'.
    Types of parameters 'encoding' and 'encoding' are incompatible.
      Type 'string' is not assignable to type '"ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | undefined'.

299     _write(chunk: any, encoding: BufferEncoding | undefined, callback: (error?: Error | null) => void): void;
        ~~~~~~


Found 1 error.
```

got v11.5.0 introduced compilation error described in https://github.com/sindresorhus/got/issues/1350.
This issue suggests that upgrading `@types/node` to v14.0.19+ solves the problem so let's just make this upgrade.
