### PR TITLE
fix: make load handle imports properly

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -41,7 +41,7 @@ export class GoogleProtoFilesRoot extends protobuf.Root {
       // on.
       'rpc',
       'type',
-    ].map(dir => path.join(__dirname, '../../', 'google', dir));
+    ].map(dir => path.join(__dirname, '..', '..', 'google', dir));
 
     if (!COMMON_PROTO_FILES) {
       COMMON_PROTO_FILES = commonProtoDirs
@@ -66,10 +66,7 @@ export class GoogleProtoFilesRoot extends protobuf.Root {
       return includePath;
     }
 
-    const fullIncludePath = path.join(
-      __dirname,
-      path.relative(__dirname, includePath)
-    );
+    const fullIncludePath = path.join(__dirname, '..', '..', includePath);
     const commonProtoFiles = GoogleProtoFilesRoot.getCommonProtoFiles();
 
     if (commonProtoFiles.indexOf(fullIncludePath) > -1) {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -79,3 +79,23 @@ describe('loadSync', () => {
     assert(root.lookup('test.TestMessage') instanceof protobuf.Type);
   });
 });
+
+describe('load real proto file', () => {
+  it('should load speech.v1', async () => {
+    const root = await googleProtoFiles.load(googleProtoFiles.speech.v1);
+    assert(
+      root.lookup('google.cloud.speech.v1.RecognizeRequest') instanceof
+        protobuf.Type
+    );
+  });
+
+  it('should load embeddedAssistant.v1alpha2', async () => {
+    const root = await googleProtoFiles.load(
+      googleProtoFiles.embeddedAssistant.v1alpha2
+    );
+    assert(
+      root.lookup('google.assistant.embedded.v1alpha2.AssistRequest') instanceof
+        protobuf.Type
+    );
+  });
+});


### PR DESCRIPTION
Fixes #297. Apparently, it never worked properly because `path.relative` in the original code was obviously misused.