### PR TITLE
test: update tests to reflect upstream fix

### DIFF
--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -64,9 +64,7 @@ describe('loadSync', () => {
     'library.proto'
   );
   it('should not be able to load test file using protobufjs directly', () => {
-    const root = protobuf.loadSync(TEST_FILE);
-    // Common proto that should not have been loaded.
-    assert.strictEqual(root.lookup('google.api.Http'), null);
+    assert.throws(() => protobuf.loadSync(TEST_FILE));
   });
 
   it('should load a test file that relies on common protos', () => {


### PR DESCRIPTION
The upstream behaviour in protobufjs was changed to throw an error rather than return `null`:

See: https://github.com/protobufjs/protobuf.js/pull/1817