### PR TITLE
fix: Revert "test: update tests to reflect upstream fix"

### DIFF
--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -64,7 +64,9 @@ describe('loadSync', () => {
     'library.proto'
   );
   it('should not be able to load test file using protobufjs directly', () => {
-    assert.throws(() => protobuf.loadSync(TEST_FILE));
+    const root = protobuf.loadSync(TEST_FILE);
+    // Common proto that should not have been loaded.
+    assert.strictEqual(root.lookup('google.api.Http'), null);
   });
 
   it('should load a test file that relies on common protos', () => {


### PR DESCRIPTION
With the revert of protobuf.js change, #448 should also be reverted.