### PR TITLE
chore: remove test that depended on protobufjs error, now protobufjs correctly fails not finding the import

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walkdir": "^0.4.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.21",
+    "@compodoc/compodoc": "^1.1.9",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",
     "@types/proxyquire": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walkdir": "^0.4.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.21",
+    "@compodoc/compodoc": "^1.1.21",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",
     "@types/proxyquire": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walkdir": "^0.4.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.9",
+    "@compodoc/compodoc": "1.1.21",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",
     "@types/proxyquire": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walkdir": "^0.4.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.9",
+    "@compodoc/compodoc": "1.1.9",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",
     "@types/proxyquire": "^1.3.28",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walkdir": "^0.4.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.21",
+    "@compodoc/compodoc": "1.1.9",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",
     "@types/proxyquire": "^1.3.28",

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -63,11 +63,6 @@ describe('loadSync', () => {
     '../../test/fixtures',
     'library.proto'
   );
-  it('should not be able to load test file using protobufjs directly', () => {
-    const root = protobuf.loadSync(TEST_FILE);
-    // Common proto that should not have been loaded.
-    assert.strictEqual(root.lookup('google.api.Http'), null);
-  });
 
   it('should load a test file that relies on common protos', () => {
     const root = googleProtoFiles.loadSync(TEST_FILE);


### PR DESCRIPTION
fixes #482 

see https://github.com/protobufjs/protobuf.js/pull/1960